### PR TITLE
ci: add branch names to trigger github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,13 @@ on:
   # Trigger the workflow every time you push to the `main` branch
   # Using a different branch name? Replace `main` with your branch’s name
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
+      - 'feature/**'
+      - 'fix/**'
+      - 'hotfix/**'
+      - 'develop/**'
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
@@ -44,6 +50,7 @@ jobs:
         # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
+    if: ${{ success() && github.ref_name == 'main' }}
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
- It will only execute the Deploy job when on main branch.
- Now is possible to trigger Lint and Build jobs for development branches (e.g.  feature, etc).